### PR TITLE
Updated the GD cropper to maintain transparency in png

### DIFF
--- a/code/Cropper/GD.php
+++ b/code/Cropper/GD.php
@@ -21,6 +21,12 @@ class GD extends GenericCropper {
 		if(!$new) {
 			throw new GD_ResourceException();
 		}
+		
+		if ($extension == 'png') {
+			imagealphablending($new, false );
+			imagesavealpha($new, true);
+		}
+		
 		$resampleResult = imagecopyresampled(
 			$new,
 			$existing,


### PR DESCRIPTION
I had an issue generating transparent png's with the cropperfield. I've added a check to the GD/crop function to check for png & then save the alpha.
